### PR TITLE
Switch to py.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 __pycache__/
 /.coverage
 /.tox
-/cover/
+/htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ before_install:
 install:
   - pip install -r requirements.txt
 script:
-  - nosetests
+  - PYTHONPATH=. py.test
 after_script:
   - pylint zeyple -f colorized -r no

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pygpgme==0.3
 six==1.9.0
-nose==1.3.4
+pytest==2.7.2
+pytest-cov==1.8.1
 mock==1.0.1
 coverage==3.7.1
 tox==2.1.1

--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -27,20 +27,16 @@ class ZeypleTest(unittest.TestCase):
     def test_config(self):
         """Parses the configuration file properly"""
 
-        self.assertEqual(
-           self.zeyple._config.get('zeyple', 'log_file'),
-           '/tmp/zeyple.log'
-        )
+        log_file = self.zeyple._config.get('zeyple', 'log_file')
+        assert log_file == '/tmp/zeyple.log'
 
     def test_user_key(self):
         """Returns the right ID for the given email address"""
 
-        self.assertIsNone(self.zeyple._user_key('non_existant@example.org'))
+        assert self.zeyple._user_key('non_existant@example.org') is None
 
-        self.assertEqual(
-            self.zeyple._user_key('torvalds@linux-foundation.org'),
-            LINUS_ID
-        )
+        user_key = self.zeyple._user_key('torvalds@linux-foundation.org')
+        assert user_key == LINUS_ID
 
     def test_encrypt_with_plain_text(self):
         """Encrypts plain text"""
@@ -48,13 +44,13 @@ class ZeypleTest(unittest.TestCase):
         encrypted = self.zeyple._encrypt(
             'The key is under the carpet.', [LINUS_ID]
         )
-        self.assertTrue(is_encrypted(encrypted))
+        assert is_encrypted(encrypted)
 
     def test_encrypt_with_unicode(self):
         """Encrypts Unicode text"""
 
         encrypted = self.zeyple._encrypt('héhé', [LINUS_ID])
-        self.assertTrue(is_encrypted(encrypted))
+        assert is_encrypted(encrypted)
 
     def test_process_message_with_simple_message(self):
         """Encrypts simple messages"""
@@ -71,8 +67,8 @@ class ZeypleTest(unittest.TestCase):
             test ðßïð
         """), ["torvalds@linux-foundation.org"])
 
-        self.assertIsNotNone(emails[0]['X-Zeyple'])
-        self.assertTrue(is_encrypted(emails[0].get_payload().encode('utf-8')))
+        assert emails[0]['X-Zeyple'] is not None
+        assert is_encrypted(emails[0].get_payload().encode('utf-8'))
 
 
     def test_process_message_with_multipart_message(self):
@@ -113,8 +109,8 @@ class ZeypleTest(unittest.TestCase):
             --=_504b4162.Gyt30puFsMOHWjpCATT1XRbWoYI1iR/sT4UX78zEEMJbxu+h--
         """), ["torvalds@linux-foundation.org"])
 
-        self.assertIsNotNone(emails[0]['X-Zeyple'])
-        self.assertTrue(emails[0].is_multipart())
+        assert emails[0]['X-Zeyple'] is not None
+        assert emails[0].is_multipart() is not None
         for part in emails[0].walk():
-            self.assertFalse(is_encrypted(part.as_string().encode('utf-8')))
+            assert not is_encrypted(part.as_string().encode('utf-8'))
 

--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -70,7 +70,6 @@ class ZeypleTest(unittest.TestCase):
         assert emails[0]['X-Zeyple'] is not None
         assert is_encrypted(emails[0].get_payload().encode('utf-8'))
 
-
     def test_process_message_with_multipart_message(self):
         """Ignores multipart messages"""
 

--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -28,7 +28,7 @@ class ZeypleTest(unittest.TestCase):
         """Parses the configuration file properly"""
 
         self.assertEqual(
-            self.zeyple._config.get('zeyple', 'log_file'),
+           self.zeyple._config.get('zeyple', 'log_file'),
            '/tmp/zeyple.log'
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ skipsdist = True
 
 [testenv]
 deps = -rrequirements.txt
+setenv =
+    PYTHONPATH = {toxinidir}
 commands =
     pep8 --show-pep8 zeyple
-    nosetests --with-coverage --cover-html --cover-package=zeyple
+    py.test {posargs:--cov-report=html --cov=zeyple/}


### PR DESCRIPTION
Py.test is awesome, better, and so on.

[py.test gives you a full analysis on assert statements.](https://pytest.org/latest/assert.html#asserting-with-the-assert-statement)

[py.test has a `--pdb` options which pops up a pdb right where it failed](https://pytest.org/latest/usage.html#dropping-to-pdb-python-debugger-on-failures)

Everybody should use `py.test`.

In addition to this, I modified the `tox.ini` configuration so that you can run `tox -e py27 -- --pdb` and it will run `py.test --pdb` in the background. [see there](https://tox.readthedocs.org/en/latest/config.html#substitutions-for-positional-arguments-in-commands)