### PR TITLE
Added zeyple-vagrant to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Just comment/uncomment the line `content_filter = zeyple` in your `/etc/postfix/
 
 Although tested only with [Postfix](http://www.postfix.org/), Zeyple should integrate nicely with any MTA which provides a [filter](http://www.postfix.org/FILTER_README.html "Postfix After-Queue Content Filter")/hook mechanism. Please let me know if you experiment with this.
 
+## Vagrant
+
+A fully-setup test-environment is available to easily test your modifications.
+[Vagrant](https://www.vagrantup.com/) and a compatible virtualization environment ([VirtualBox](https://www.virtualbox.org/) for example) are required.
+
+Visit [zeyple-vagrant](https://github.com/Nithanim/zeyple-vagrant) for download and more information.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
This commit aims to integrate the zeyple-vagrant repository into the readme for fixing the issue #18.