### PR TITLE
Add ansible as an installation option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,9 +4,9 @@ A few options are available to install Zeyple, feel free to use the one that
 suits you best.
 
 1. [Chef cookbook](https://github.com/infertux/chef-zeyple)
-1. [Third-party Bash
-   script](https://github.com/bastelfreak/scripts/blob/master/setup_zeyple.sh)
-   [[1]](#fn-1)
+1. [Bash script (3rd party)](
+	 https://github.com/bastelfreak/scripts/blob/master/setup_zeyple.sh) [[1]](#fn-1)
+1. [ansible role (3rd party)](https://galaxy.ansible.com/mimacom/zeyple/)
 1. By hand - follow instructions below: [[1]](#fn-1)
 
 ---
@@ -39,26 +39,34 @@ You need to be _root_ here - make sure you understand what you are doing.
 
 1. Plug it into Postfix.
 
-    ```bash cat >> /etc/postfix/master.cf <<'CONF' zeyple    unix  -       n
-    n       -       -       pipe user=zeyple argv=/usr/local/bin/zeyple.py
-    ${recipient}
 
-    localhost:10026 inet  n       -       n       -       10      smtpd -o
-    content_filter= -o
-    receive_override_options=no_unknown_recipient_checks,no_header_body_checks,no_milters
-    -o smtpd_helo_restrictions= -o smtpd_client_restrictions= -o
-    smtpd_sender_restrictions= -o
-    smtpd_recipient_restrictions=permit_mynetworks,reject -o
-    mynetworks=127.0.0.0/8 -o smtpd_authorized_xforward_hosts=127.0.0.0/8 CONF
+    ```bash
+    cat >> /etc/postfix/master.cf <<'CONF'
+    zeyple    unix  -       n       n       -       -       pipe
+      user=zeyple argv=/usr/local/bin/zeyple.py ${recipient}
 
-    cat >> /etc/postfix/main.cf <<'CONF' content_filter = zeyple CONF
+    localhost:10026 inet  n       -       n       -       10      smtpd
+      -o content_filter=
+      -o receive_override_options=no_unknown_recipient_checks,no_header_body_checks,no_milters
+      -o smtpd_helo_restrictions=
+      -o smtpd_client_restrictions=
+      -o smtpd_sender_restrictions=
+      -o smtpd_recipient_restrictions=permit_mynetworks,reject
+      -o mynetworks=127.0.0.0/8
+      -o smtpd_authorized_xforward_hosts=127.0.0.0/8
+    CONF
 
-    cp zeyple.py /usr/local/bin/zeyple.py chmod 744 /usr/local/bin/zeyple.py &&
-    chown zeyple: /usr/local/bin/zeyple.py
+    cat >> /etc/postfix/main.cf <<'CONF'
+    content_filter = zeyple
+    CONF
+
+    cp zeyple.py /usr/local/bin/zeyple.py
+    chmod 744 /usr/local/bin/zeyple.py && chown zeyple: /usr/local/bin/zeyple.py
 
     touch /var/log/zeyple.log && chown zeyple: /var/log/zeyple.log
 
-    postfix reload ```
+    postfix reload
+    ```
 
     As a side note, `localhost:10026` is used to reinject email into the queue
     bypassing the _zeyple_ `content_filter`.
@@ -79,4 +87,3 @@ Manually remove the added lines in `/etc/postfix/{main,master}.cf` then
 
 ```bash rm -rfv /etc/zeyple.conf /usr/local/bin/zeyple.py /var/lib/zeyple
 /var/log/zeyple.log userdel zeyple postfix reload ```
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,17 +15,22 @@ You need to be _root_ here - make sure you understand what you are doing.
 
 1. Install GnuPG and the Python wrapper for the GPGME library.
 
+    ```
     apt-get install gnupg python-gpgme sudo
+    ```
 
 1. Since Zeyple is going to read and encrypt your emails, it is recommended to
    create a dedicated user account for this task (using the "postfix" user is
    very discouraged according to [the
    doc](http://www.postfix.org/FILTER_README.html).
 
+    ```
     adduser --system --no-create-home --disabled-login zeyple
+    ```
 
 1. Import public keys for all potential recipients.
 
+    ```
     mkdir -p /var/lib/zeyple/keys
     chmod 700 /var/lib/zeyple/keys
     chown zeyple /var/lib/zeyple/keys
@@ -34,10 +39,13 @@ You need to be _root_ here - make sure you understand what you are doing.
     sudo -u zeyple gpg --homedir /var/lib/zeyple/keys \
       --keyserver hkp://keys.gnupg.net \
       --search you@domain.tld
+    ```
 
 1. Configure `/etc/zeyple.conf` from the template `zeyple.conf.example`.
 
+    ```
     cp zeyple.conf.example /etc/zeyple.conf
+    ```
 
     Adjust the file for your needs. Default values should be fine in most cases.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,27 +15,31 @@ You need to be _root_ here - make sure you understand what you are doing.
 
 1. Install GnuPG and the Python wrapper for the GPGME library.
 
-    ```bash apt-get install gnupg python-gpgme sudo ```
+    apt-get install gnupg python-gpgme sudo
 
 1. Since Zeyple is going to read and encrypt your emails, it is recommended to
    create a dedicated user account for this task (using the "postfix" user is
    very discouraged according to [the
    doc](http://www.postfix.org/FILTER_README.html).
 
-    ```bash adduser --system --no-create-home --disabled-login zeyple ```
+    adduser --system --no-create-home --disabled-login zeyple
 
 1. Import public keys for all potential recipients.
 
-    ```bash mkdir -p /var/lib/zeyple/keys && chmod 700 /var/lib/zeyple/keys &&
-    chown zeyple: /var/lib/zeyple/keys sudo -u zeyple gpg --homedir
-    /var/lib/zeyple/keys --keyserver hkp://keys.gnupg.net --search
-    you@domain.tld # repeat for each key ```
+    mkdir -p /var/lib/zeyple/keys
+    chmod 700 /var/lib/zeyple/keys
+    chown zeyple /var/lib/zeyple/keys
+
+    # repeat this for each key / e-mail address
+    sudo -u zeyple gpg --homedir /var/lib/zeyple/keys \
+      --keyserver hkp://keys.gnupg.net \
+      --search you@domain.tld
 
 1. Configure `/etc/zeyple.conf` from the template `zeyple.conf.example`.
 
-    ```bash cp zeyple.conf.example /etc/zeyple.conf vim /etc/zeyple.conf ```
+    cp zeyple.conf.example /etc/zeyple.conf
 
-    Default values should be fine in most cases.
+    Adjust the file for your needs. Default values should be fine in most cases.
 
 1. Plug it into Postfix.
 
@@ -85,5 +89,6 @@ my key with `gpg --recv-keys 09A98A9B` then running `git tag -v $(git tag | tail
 
 Manually remove the added lines in `/etc/postfix/{main,master}.cf` then
 
-```bash rm -rfv /etc/zeyple.conf /usr/local/bin/zeyple.py /var/lib/zeyple
-/var/log/zeyple.log userdel zeyple postfix reload ```
+    rm -rf /etc/zeyple.conf /usr/local/bin/zeyple.py /var/lib/zeyple /var/log/zeyple.log
+    userdel zeyple
+    postfix reload

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,12 @@
 # Install
 
-A few options are available to install Zeyple, feel free to use the one that suits you best.
+A few options are available to install Zeyple, feel free to use the one that
+suits you best.
 
 1. [Chef cookbook](https://github.com/infertux/chef-zeyple)
-1. [Third-party Bash script](https://github.com/bastelfreak/scripts/blob/master/setup_zeyple.sh) [[1]](#fn-1)
+1. [Third-party Bash
+   script](https://github.com/bastelfreak/scripts/blob/master/setup_zeyple.sh)
+   [[1]](#fn-1)
 1. By hand - follow instructions below: [[1]](#fn-1)
 
 ---
@@ -12,78 +15,68 @@ You need to be _root_ here - make sure you understand what you are doing.
 
 1. Install GnuPG and the Python wrapper for the GPGME library.
 
-    ```bash
-    apt-get install gnupg python-gpgme sudo
-    ```
+    ```bash apt-get install gnupg python-gpgme sudo ```
 
-1. Since Zeyple is going to read and encrypt your emails, it is recommended to create a dedicated user account for this task (using the "postfix" user is very discouraged according to [the doc](http://www.postfix.org/FILTER_README.html).
+1. Since Zeyple is going to read and encrypt your emails, it is recommended to
+   create a dedicated user account for this task (using the "postfix" user is
+   very discouraged according to [the
+   doc](http://www.postfix.org/FILTER_README.html).
 
-    ```bash
-    adduser --system --no-create-home --disabled-login zeyple
-    ```
+    ```bash adduser --system --no-create-home --disabled-login zeyple ```
 
 1. Import public keys for all potential recipients.
 
-    ```bash
-    mkdir -p /var/lib/zeyple/keys && chmod 700 /var/lib/zeyple/keys && chown zeyple: /var/lib/zeyple/keys
-    sudo -u zeyple gpg --homedir /var/lib/zeyple/keys --keyserver hkp://keys.gnupg.net --search you@domain.tld # repeat for each key
-    ```
+    ```bash mkdir -p /var/lib/zeyple/keys && chmod 700 /var/lib/zeyple/keys &&
+    chown zeyple: /var/lib/zeyple/keys sudo -u zeyple gpg --homedir
+    /var/lib/zeyple/keys --keyserver hkp://keys.gnupg.net --search
+    you@domain.tld # repeat for each key ```
 
 1. Configure `/etc/zeyple.conf` from the template `zeyple.conf.example`.
 
-    ```bash
-    cp zeyple.conf.example /etc/zeyple.conf
-    vim /etc/zeyple.conf
-    ```
+    ```bash cp zeyple.conf.example /etc/zeyple.conf vim /etc/zeyple.conf ```
 
     Default values should be fine in most cases.
 
 1. Plug it into Postfix.
 
-    ```bash
-    cat >> /etc/postfix/master.cf <<'CONF'
-    zeyple    unix  -       n       n       -       -       pipe
-      user=zeyple argv=/usr/local/bin/zeyple.py ${recipient}
+    ```bash cat >> /etc/postfix/master.cf <<'CONF' zeyple    unix  -       n
+    n       -       -       pipe user=zeyple argv=/usr/local/bin/zeyple.py
+    ${recipient}
 
-    localhost:10026 inet  n       -       n       -       10      smtpd
-      -o content_filter=
-      -o receive_override_options=no_unknown_recipient_checks,no_header_body_checks,no_milters
-      -o smtpd_helo_restrictions=
-      -o smtpd_client_restrictions=
-      -o smtpd_sender_restrictions=
-      -o smtpd_recipient_restrictions=permit_mynetworks,reject
-      -o mynetworks=127.0.0.0/8
-      -o smtpd_authorized_xforward_hosts=127.0.0.0/8
-    CONF
+    localhost:10026 inet  n       -       n       -       10      smtpd -o
+    content_filter= -o
+    receive_override_options=no_unknown_recipient_checks,no_header_body_checks,no_milters
+    -o smtpd_helo_restrictions= -o smtpd_client_restrictions= -o
+    smtpd_sender_restrictions= -o
+    smtpd_recipient_restrictions=permit_mynetworks,reject -o
+    mynetworks=127.0.0.0/8 -o smtpd_authorized_xforward_hosts=127.0.0.0/8 CONF
 
-    cat >> /etc/postfix/main.cf <<'CONF'
-    content_filter = zeyple
-    CONF
+    cat >> /etc/postfix/main.cf <<'CONF' content_filter = zeyple CONF
 
-    cp zeyple.py /usr/local/bin/zeyple.py
-    chmod 744 /usr/local/bin/zeyple.py && chown zeyple: /usr/local/bin/zeyple.py
+    cp zeyple.py /usr/local/bin/zeyple.py chmod 744 /usr/local/bin/zeyple.py &&
+    chown zeyple: /usr/local/bin/zeyple.py
 
     touch /var/log/zeyple.log && chown zeyple: /var/log/zeyple.log
 
-    postfix reload
-    ```
+    postfix reload ```
 
-    As a side note, `localhost:10026` is used to reinject email into the queue bypassing the _zeyple_ `content_filter`.
+    As a side note, `localhost:10026` is used to reinject email into the queue
+    bypassing the _zeyple_ `content_filter`.
 
-You are good to go!
-You can send you an email with `date | mail -s test root` and check it is encrypted.
+You are good to go!  You can send you an email with `date | mail -s test root`
+and check it is encrypted.
 
 ---
 
-<a name="fn-1">[1]</a> _The Git repository is GPG signed - if you cloned the repository locally, you can make sure it has not been tampered with by importing my key with `gpg --recv-keys 09A98A9B` then running `git tag -v $(git tag | tail -1)`._
+<a name="fn-1">[1]</a> _The Git repository is GPG signed - if you cloned the
+repository locally, you can make sure it has not been tampered with by importing
+my key with `gpg --recv-keys 09A98A9B` then running `git tag -v $(git tag | tail
+-1)`._
 
 # Uninstall
 
 Manually remove the added lines in `/etc/postfix/{main,master}.cf` then
 
-```bash
-rm -rfv /etc/zeyple.conf /usr/local/bin/zeyple.py /var/lib/zeyple /var/log/zeyple.log
-userdel zeyple
-postfix reload
-```
+```bash rm -rfv /etc/zeyple.conf /usr/local/bin/zeyple.py /var/lib/zeyple
+/var/log/zeyple.log userdel zeyple postfix reload ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 1. Finally it puts them back into the queue
 
     ```
-    unencrypted email   ||   encrypted email
+         unencrypted email   ||   encrypted email
     sender --> Postfix --> Zeyple --> Postfix --> recipient(s)
     ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# ZEYPLE: Zeyple Encrypts Your Precious Log Emails [![Build Status](https://travis-ci.org/infertux/zeyple.png?branch=master)](https://travis-ci.org/infertux/zeyple)
+# ZEYPLE: Zeyple Encrypts Your Precious Log Emails [![Build
+Status](https://travis-ci.org/infertux/zeyple.svg?branch=master)](https://travis-ci.org/infertux/zeyple)
 
 **Zeyple automatically encrypts outgoing emails with GPG:**
 
@@ -6,13 +7,14 @@
 1. Then encrypts them if it's got the recipient's GPG public key
 1. Finally it puts them back into the queue
 
-<pre>
-     unencrypted email   ||   encrypted email
-sender --> Postfix --> Zeyple --> Postfix --> recipient(s)
-</pre>
+          unencrypted email   ||   encrypted email
+    sender --> Postfix --> Zeyple --> Postfix --> recipient(s)
 
-_Why should I care? If you are a sysadmin who receives emails from various monitoring tools like Logwatch, Monit, Fail2ban, Smartd, Cron, whatever - it goes without saying that those emails contain lots of information about your servers.
-Information that may be intercepted by some malicious hacker sniffing SMTP traffic, your email provider, &lt;insert your (paranoid) reason here&gt;...
+_Why should I care? If you are a sysadmin who receives emails from various
+monitoring tools like Logwatch, Monit, Fail2ban, Smartd, Cron, whatever - it
+goes without saying that those emails contain lots of information about your
+servers.  Information that may be intercepted by some malicious hacker sniffing
+SMTP traffic, your email provider, &lt;insert your (paranoid) reason here&gt;...
 Why would you take that risk - encrypt them all!_
 
 ## Install & upgrade
@@ -21,23 +23,31 @@ See [INSTALL.md](INSTALL.md) & [UPGRADE.md](UPGRADE.md).
 
 ## Disable/enable Zeyple
 
-Just comment/uncomment the line `content_filter = zeyple` in your `/etc/postfix/main.cf` then `postfix reload`.
+Just comment/uncomment the line `content_filter = zeyple` in your
+`/etc/postfix/main.cf` then `postfix reload`.
 
 ## Key management
 
 * List of keys: `sudo -u zeyple gpg --homedir /var/lib/zeyple/keys --list-keys`
-* Update imported keys: `sudo -u zeyple gpg --homedir /var/lib/zeyple/keys --keyserver hkp://keys.gnupg.net --refresh-keys`
-* Import a new key: `sudo -u zeyple gpg --homedir /var/lib/zeyple/keys --keyserver hkp://keys.gnupg.net --search you@domain.tld`
+* Update imported keys: `sudo -u zeyple gpg --homedir /var/lib/zeyple/keys
+  --keyserver hkp://keys.gnupg.net --refresh-keys`
+* Import a new key: `sudo -u zeyple gpg --homedir /var/lib/zeyple/keys
+  --keyserver hkp://keys.gnupg.net --search you@domain.tld`
 
 ## Integration with other MTAs
 
-Although tested only with [Postfix](http://www.postfix.org/), Zeyple should integrate nicely with any MTA which provides a [filter](http://www.postfix.org/FILTER_README.html "Postfix After-Queue Content Filter")/hook mechanism. Please let me know if you experiment with this.
+Although tested only with [Postfix](http://www.postfix.org/), Zeyple should
+integrate nicely with any MTA which provides a
+[filter](http://www.postfix.org/FILTER_README.html "Postfix After-Queue Content
+Filter")/hook mechanism. Please let me know if you experiment with this.
 
 ## Vagrant
 
 A fully-setup test-environment is available to easily test your modifications.
-[Vagrant](https://www.vagrantup.com/) and a compatible virtualization environment ([VirtualBox](https://www.virtualbox.org/) for example) are required.
-Visit [zeyple-vagrant](https://github.com/Nithanim/zeyple-vagrant) for download and more information.
+[Vagrant](https://www.vagrantup.com/) and a compatible virtualization
+environment ([VirtualBox](https://www.virtualbox.org/) for example) are
+required.  Visit [zeyple-vagrant](https://github.com/Nithanim/zeyple-vagrant)
+for download and more information.
 
 ## Contributing
 
@@ -45,7 +55,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Kudos
 
-Many thanks to [Harry Knitter](http://www.linux-magazine.com/Issues/2013/153/Email-Encryption-with-Zeyple) for his feedback to help make Zeyple more robust.
+Many thanks to [Harry
+Knitter](http://www.linux-magazine.com/Issues/2013/153/Email-Encryption-with-Zeyple)
+for his feedback to help make Zeyple more robust.
 
 ## Blog posts & articles
 
@@ -55,9 +67,10 @@ Many thanks to [Harry Knitter](http://www.linux-magazine.com/Issues/2013/153/Ema
 
 ## Support
 
-Bitcoin donations to support Zeyple: [192TgFGjiRKCJtXAQAv1urnvQXGZV2wwBt](bitcoin:192TgFGjiRKCJtXAQAv1urnvQXGZV2wwBt?message=Zeyple) :)
+Bitcoin donations to support Zeyple:
+[192TgFGjiRKCJtXAQAv1urnvQXGZV2wwBt](bitcoin:192TgFGjiRKCJtXAQAv1urnvQXGZV2wwBt?message=Zeyple)
+:)
 
 ## License
 
 AGPLv3+
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# ZEYPLE: Zeyple Encrypts Your Precious Log Emails [![Build
-Status](https://travis-ci.org/infertux/zeyple.svg?branch=master)](https://travis-ci.org/infertux/zeyple)
+# ZEYPLE: Zeyple Encrypts Your Precious Log Emails
+
+[![Build Status](https://travis-ci.org/infertux/zeyple.svg?branch=master)](https://travis-ci.org/infertux/zeyple)
 
 **Zeyple automatically encrypts outgoing emails with GPG:**
 
@@ -7,8 +8,9 @@ Status](https://travis-ci.org/infertux/zeyple.svg?branch=master)](https://travis
 1. Then encrypts them if it's got the recipient's GPG public key
 1. Finally it puts them back into the queue
 
-          unencrypted email   ||   encrypted email
+    unencrypted email   ||   encrypted email
     sender --> Postfix --> Zeyple --> Postfix --> recipient(s)
+
 
 _Why should I care? If you are a sysadmin who receives emails from various
 monitoring tools like Logwatch, Monit, Fail2ban, Smartd, Cron, whatever - it

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 1. Then encrypts them if it's got the recipient's GPG public key
 1. Finally it puts them back into the queue
 
+    ```
     unencrypted email   ||   encrypted email
     sender --> Postfix --> Zeyple --> Postfix --> recipient(s)
+    ```
 
 
 _Why should I care? If you are a sysadmin who receives emails from various


### PR DESCRIPTION
For those of you guys who want to use ansible, I'm managing now an ansible-role (test-driven and CI) to install zeyple. See: https://galaxy.ansible.com/mimacom/zeyple/

It currently works on Enterprise Linux / CentOS. I'm happy to extend this for Debian/Ubuntu, if you want to.