### PR TITLE
Add ansible as an installation option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,7 @@ A few options are available to install Zeyple, feel free to use the one that sui
 
 1. [Chef cookbook](https://github.com/infertux/chef-zeyple)
 1. [Third-party Bash script](https://github.com/bastelfreak/scripts/blob/master/setup_zeyple.sh) [[1]](#fn-1)
+1. [ansible role (3rd party)](https://galaxy.ansible.com/mimacom/zeyple/)
 1. By hand - follow instructions below: [[1]](#fn-1)
 
 ---


### PR DESCRIPTION
For those of you guys who want to use ansible, I'm managing now an ansible-role (test-driven and CI) to install zeyple. See: https://galaxy.ansible.com/mimacom/zeyple/

It currently works on Enterprise Linux / CentOS. I'm happy to extend this for Debian/Ubuntu, if you want to.