### PR TITLE
Decode payload before encrypting

### DIFF
--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -170,7 +170,9 @@ class Zeyple:
             payload = message.get_payload()
 
         else:
-            payload = in_message.get_payload()
+            # get and decode payload according to the
+            # Content-Transfer-Encoding header
+            payload = in_message.get_payload(decode=True)
             payload = encode_string(payload)
 
             quoted_printable = email.charset.Charset('ascii')


### PR DESCRIPTION
This fixes #39. Payload is decoded according to the Content-Transfer-Encoding
header. The issue did not occur when a multipart message was sent.