### PR TITLE
Copy content header values from original single part email to new payload

### DIFF
--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -114,7 +114,6 @@ class ZeypleTest(unittest.TestCase):
 
         mime_message = dedent("""\
             --BOUNDARY
-            MIME-Version: 1.0
             Content-Type: text/plain
 
             test
@@ -138,7 +137,6 @@ class ZeypleTest(unittest.TestCase):
 
         mime_message = dedent("""\
             --BOUNDARY
-            MIME-Version: 1.0
             Content-Type: text/plain; charset=utf-8
             Content-Transfer-Encoding: 8bit
 

--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -115,8 +115,7 @@ class ZeypleTest(unittest.TestCase):
         mime_message = dedent("""\
             --BOUNDARY
             MIME-Version: 1.0
-            Content-Type: text/plain; charset="us-ascii"
-            Content-Transfer-Encoding: quoted-printable
+            Content-Type: text/plain
 
             test
             --BOUNDARY--""")
@@ -140,10 +139,10 @@ class ZeypleTest(unittest.TestCase):
         mime_message = dedent("""\
             --BOUNDARY
             MIME-Version: 1.0
-            Content-Type: text/plain; charset="us-ascii"
-            Content-Transfer-Encoding: quoted-printable
+            Content-Type: text/plain; charset=utf-8
+            Content-Transfer-Encoding: 8bit
 
-            =C3=A4 =C3=B6 =C3=BC
+            ä ö ü
             --BOUNDARY--""")
 
         email = self.zeyple.process_message(dedent("""\

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -115,9 +115,6 @@ class Zeyple:
             if key_id:
                 out_message = self._encrypt_message(in_message, key_id)
 
-                # Delete Content-Transfer-Encoding if present to default to
-                # "7bit" otherwise Thunderbird seems to hang in some cases.
-                del out_message["Content-Transfer-Encoding"]
             else:
                 logging.warn("No keys found, message will be sent unencrypted")
                 out_message = copy.copy(in_message)
@@ -215,7 +212,7 @@ class Zeyple:
                 'Content-Type',
                 'multipart/encrypted',
             )
-
+        del out_message['Content-Transfer-Encoding']
         out_message.set_param('protocol', 'application/pgp-encrypted')
         out_message.set_payload([version, encrypted])
 

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -173,8 +173,8 @@ class Zeyple:
                 in_message.get_content_maintype(),
                 in_message.get_content_subtype()
             )
-
-            message.set_payload(in_message.get_payload())
+            payload = encode_string(in_message.get_payload())
+            message.set_payload(payload)
 
             # list of additional parameters in content-type
             params = in_message.get_params()

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -169,19 +169,24 @@ class Zeyple:
             payload = message.get_payload()
 
         else:
-            payload = in_message.get_payload()
-            maintype = in_message.get_content_maintype()
-            subtype = in_message.get_content_subtype()
-            charset = in_message.get_content_charset()
-            encoding = in_message["Content-Transfer-Encoding"]
-
             message = email.mime.nonmultipart.MIMENonMultipart(
-                maintype, subtype, charset=charset
+                in_message.get_content_maintype(),
+                in_message.get_content_subtype()
             )
+
+            message.set_payload(in_message.get_payload())
+
+            # list of additional parameters in content-type
+            params = in_message.get_params()
+            if params:
+                # first item is the main/sub type so discard it
+                del params[0]
+                for param, value in params:
+                    message.set_param(param, value, "Content-Type", False)
+
+            encoding = in_message["Content-Transfer-Encoding"]
             if encoding:
                 message.add_header("Content-Transfer-Encoding", encoding)
-
-            message.set_payload(payload)
 
             del message['MIME-Version']
 


### PR DESCRIPTION
Single part emails were not rendered correctly in clients due to the hard coded content headers. 

Rather than decode the payload then try to determine what encoding the message needs, just leave the payload as is and copy the original content headers to the new payload.  We can safely assume the client will set these headers correctly and this is essentially the same thing you're doing for multi-part emails.

This addresses issue #34 and #41 and #42.  I've tested by sending content from those issues through zeyple and the resulting email is formatted and rendered correctly.

I also added a few more MIME-Version header deletes that were being inserted into parts.