### PR TITLE
prevent leaking data through unencrypted subject

### DIFF
--- a/zeyple/zeyple.conf.example
+++ b/zeyple/zeyple.conf.example
@@ -1,5 +1,7 @@
 [zeyple]
 log_file = /var/log/zeyple.log
+hide_subject = False
+hidden_subject_replacement = Zeyple encrypted message
 
 [gpg]
 home = /var/lib/zeyple/keys
@@ -7,4 +9,3 @@ home = /var/lib/zeyple/keys
 [relay]
 host = localhost
 port = 10026
-


### PR DESCRIPTION
As the subject is not encrypted by PGP it could leak sensitive data. So I thought we should go all the way and also hide the subject. It is preserved in the message body. For those who find it awkward to have similar subjects for all e-mails send by Zeyple I made this configurable and off by default.

As I don't really know how to handle multipart messages the subject is currently only preserved for plaintext messages. I need a bit of help on the multipart side. Where should the old subject being injected?