### PR TITLE
update python versions for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, pypy3
+envlist = py27, py34, py35, py36, pypy, pypy3
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
Python 3.3 should have reached EOL in September 2017 and we now have 3.6.