### PR TITLE
make _user_key case insensitive, add test

### DIFF
--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -96,6 +96,8 @@ class ZeypleTest(unittest.TestCase):
 
         user_key = self.zeyple._user_key(TEST1_EMAIL)
         assert user_key == TEST1_ID
+        user_key = self.zeyple._user_key(TEST1_EMAIL.upper())
+        assert user_key == TEST1_ID
 
     def test_encrypt_with_plain_text(self):
         """Encrypts plain text"""

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -248,7 +248,7 @@ class Zeyple:
         # for searches like "n"
         for key in self.gpg.keylist(email):
             for uid in key.uids:
-                if uid.email == email:
+                if uid.email.lower() == email.lower():
                     return key.subkeys[0].keyid
 
         return None


### PR DESCRIPTION
I figured out that getting the key id is case insensitive leading to plaintext mails when sending a mail to foo@example.com but the mail address in the key is Foo@example.com