### PR TITLE
move to python-gpg and keep python-gpgme as fallback

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,8 +14,10 @@ You need to be _root_ here - make sure you understand what you are doing.
 1. Install GnuPG and the Python wrapper for the GPGME library.
 
     ```bash
-    apt-get install gnupg python-gpgme sudo
+    apt-get install gnupg python-gpg sudo
     ```
+
+    In case `python-gpg` is not available you can also still use `python-gpgme`.
 
 1. Since Zeyple is going to read and encrypt your emails, it is recommended to create a dedicated user account for this task (using the "postfix" user is very discouraged according to [the doc](http://www.postfix.org/FILTER_README.html).
 
@@ -87,4 +89,3 @@ rm -rfv /etc/zeyple.conf /usr/local/bin/zeyple.py /var/lib/zeyple /var/log/zeypl
 userdel zeyple
 postfix reload
 ```
-


### PR DESCRIPTION
Fixes #52.
I think no major release will be required, because I tried to keep backwards compatibility with gpgme. I did an acceptance test, but apart from that I did not perform in-depth testing.