### PR TITLE
Missing keys - rules and notifications - 2nd try

### DIFF
--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -351,3 +351,24 @@ class ZeypleTest(unittest.TestCase):
         sent_messages = zeyple.process_message(contents, ['unknown@zeyple.example.com'])
         assert len(sent_messages) == 1
         assert sent_messages[0]['Subject'] == 'Verify Email'
+
+    def test_custom_missing_key_message(self):
+        contents = get_test_email()
+        missing_key_message_file = os.path.join(self.tmpdir, 'missing_key_message')
+        subject = 'No key dude!'
+        body = 'xxxYYYzzz'
+
+        with open(missing_key_message_file, 'w') as out:
+            out.write(body + '\n')
+        zeyple = self.get_zeyple(
+            DEFAULT_CONFIG_TEMPLATE + dedent("""\
+            missing_key_notification_file = {0}
+            missing_key_notification_subject = {1}
+            """).format(missing_key_message_file, subject)
+        )
+
+        sent_messages = zeyple.process_message(contents, ['unknown@zeyple.example.com'])
+
+        assert len(sent_messages) == 1
+        assert sent_messages[0]['Subject'] == subject
+        assert body in sent_messages[0].get_payload()

--- a/zeyple/zeyple.conf.example
+++ b/zeyple/zeyple.conf.example
@@ -4,7 +4,8 @@ log_file = /var/log/zeyple.log
 ### File name containing the body a notification email to be sent
 ### when no key is found. There is a nice default, however you
 ### may wish to give the recipient more specific instruction
-### how to get his key on your system:
+### how to get his key on your system. The file must be encoded
+### in UTF-8:
 
 # missing_key_notification_file = /etc/zeyple.notify
 

--- a/zeyple/zeyple.conf.example
+++ b/zeyple/zeyple.conf.example
@@ -1,6 +1,16 @@
 [zeyple]
 log_file = /var/log/zeyple.log
-force_encrypt = 1
+
+### File name containing the body a notification email to be sent
+### when no key is found. There is a nice default, however you
+### may wish to give the recipient more specific instruction
+### how to get his key on your system:
+
+# missing_key_notification_file = /etc/zeyple.notify
+
+### Subject for this email:
+
+# missing_key_notification_subject = Fix it!
 
 [gpg]
 home = /var/lib/zeyple/keys
@@ -9,3 +19,35 @@ home = /var/lib/zeyple/keys
 host = localhost
 port = 10026
 
+[missing_key_rules]
+### This rules define, what to do if the recipient has no key. The rules
+### have the format:
+###
+###    <regexp> = drop|notify|cleartext
+###
+### The recipient address will be matched against <regexp> using the Python
+### module 're'. The actions have this effect:
+###
+### - drop: Discards the message silently.
+### - notify: Send a notification to the recipient
+###
+### Examples:
+###
+### The toystory people never get important stuff and don't know how to use PGP:
+###
+###    .*\@toystory\.com$ = cleartext
+###
+### The new default - always notify:
+###
+###    . = notify
+###
+### The old behavior with "force_encrypt = 1" - in doubt drop the message:
+###
+###    . = drop
+###
+### The old behavior with "force_encrypt = 0" - sent messages without encryption
+### if we lack the key:
+###
+###    . = cleartext
+###
+### Order matters! First match wins - at least with Python 2.7+.

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -88,14 +88,16 @@ __copyright__ = 'Copyright 2012-2018 Cédric Félizard'
 
 def get_config_from_file_handle(handle):
     config = ConfigParser()
-    config.read_file(handle)
+    if sys.version_info >= (3, 2):
+        config.read_file(handle)
+    else:
+        config.readfp(handle)
     if not config.sections():
         raise IOError('Cannot open config file.')
 
     if config.has_option('zeyple', 'missing_key_notification_file'):
         file_name = config.get('zeyple', 'missing_key_notification_file')
         with open(file_name) as handle:
-            set
             config.missing_key_notification_body = handle.read()
     elif not config.has_option('zeyple', 'missing_key_notification_body'):
         config.missing_key_notification_body = \

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -187,7 +187,9 @@ class Zeyple:
             return self._get_missing_key_message(in_message, recipient)
 
     def _get_missing_key_message(self, in_message, recipient):
-        out_message = MIMEText(self.config.missing_key_notification_body)
+        out_message = MIMEText(
+            self.config.missing_key_notification_body, 'plain', 'utf-8'
+        )
         if self.config.has_option(
             'zeyple', 'missing_key_notification_subject'
         ):

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -13,9 +13,9 @@ import copy
 from io import BytesIO
 
 try:
-    from configparser import SafeConfigParser  # Python 3
+    from configparser import ConfigParser  # Python 3
 except ImportError:
-    from ConfigParser import SafeConfigParser  # Python 2
+    from ConfigParser import ConfigParser  # Python 2
 
 legacy_gpg = False
 try:
@@ -73,7 +73,7 @@ class Zeyple:
     def load_configuration(self, filename):
         """Reads and parses the config file"""
 
-        config = SafeConfigParser()
+        config = ConfigParser()
         config.read([
             os.path.join('/etc/', filename),
             filename,
@@ -264,8 +264,10 @@ class Zeyple:
             plaintext = BytesIO(payload)
             ciphertext = BytesIO()
 
-            self.gpg.encrypt(recipient, gpgme.ENCRYPT_ALWAYS_TRUST,
-                          plaintext, ciphertext)
+            self.gpg.encrypt(
+                recipient, gpgme.ENCRYPT_ALWAYS_TRUST,
+                plaintext, ciphertext
+            )
 
             return ciphertext.getvalue()
         else:


### PR DESCRIPTION
This a new pull request for "missing key notifications" feature:
- Now tox completes with just one deprecation warning, which is addressed in the code.
- Test coverage for the new functionality
- A bug or two less.
However I felt the need to change more of the code and tests - more dependency injection.
The handling of the configuration file and the log configuration happens now outside the
central zeyple class.