### PR TITLE
Support sub addressing

### DIFF
--- a/tests/test_zeyple.py
+++ b/tests/test_zeyple.py
@@ -25,6 +25,7 @@ except ImportError:
 KEYS_FNAME = os.path.join(os.path.dirname(__file__), 'keys.gpg')
 TEST1_ID = 'D6513C04E24C1F83'
 TEST1_EMAIL = 'test1@zeyple.example.com'
+TEST1_EMAIL_SUBADDRESS = 'test1+tag@zeyple.example.com'
 TEST2_ID = '0422F1C597FB1687'
 TEST2_EMAIL = 'test2@zeyple.example.com'
 TEST_EXPIRED_ID = 'ED97E21F1C7F1AC6'
@@ -103,6 +104,9 @@ class ZeypleTest(unittest.TestCase):
         assert self.zeyple._user_key('non_existant@example.org') is None
 
         user_key = self.zeyple._user_key(TEST1_EMAIL)
+        assert user_key == TEST1_ID
+
+        user_key = self.zeyple._user_key(TEST1_EMAIL_SUBADDRESS)
         assert user_key == TEST1_ID
 
     def test_encrypt_with_plain_text(self):

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -10,6 +10,7 @@ import email.mime.application
 import email.encoders
 import smtplib
 import copy
+import re
 from io import BytesIO
 
 try:
@@ -289,6 +290,11 @@ class Zeyple:
             for uid in key.uids:
                 if uid.email == email:
                     return key.subkeys[0].keyid
+
+        # Strip sub addressing tag
+        submail = re.sub('(\+[^@]+)', '', email)
+        if submail != email:
+            return self._user_key(submail)
 
         return None
 


### PR DESCRIPTION
Add support for email addresses like `monitoring+server@example.com`.
This feature is supported by several email services (see also:
https://en.wikipedia.org/wiki/Email_address#Subaddressing).

I assume that people don't include all sub addresses in their public key
at creation time and want to share the same key for multiple addresses.

With this change `_user_key()` also matches keys without sub addressing
tag when there was no explicit match before.