### PR TITLE
added support for mail and gpg key maps

### DIFF
--- a/zeyple/zeyple.conf.example
+++ b/zeyple/zeyple.conf.example
@@ -9,3 +9,5 @@ home = /var/lib/zeyple/keys
 host = localhost
 port = 10026
 
+[keymap]
+mail@example.com = AAAAAAAAAAAAAAAA

--- a/zeyple/zeyple.py
+++ b/zeyple/zeyple.py
@@ -289,7 +289,11 @@ class Zeyple:
             for uid in key.uids:
                 if uid.email == email:
                     return key.subkeys[0].keyid
-
+        if self.config.has_option('keymap'):
+            for mail_map in self.config.items('keymap'):
+                if mail_map[0] == email:
+                    for key in self.gpg.keylist('0x' + mail_map[1]):
+                        return key.subkeys[0].keyid
         return None
 
     def _add_zeyple_header(self, message):


### PR DESCRIPTION
Hi,
this PR enables user to set an email recipient based on local email => key_id map in addition to standard user id contained in the key itself.
Cheers
S